### PR TITLE
Fix heap buffer overflow in camcom_packet_clean_all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ caCamcom_SRCS += camcom_lex.c
 caCamcom_SRCS  += camcom_support.c
 caCamcom_LIBS	+= $(EPICS_BASE_HOST_LIBS)
 
+BIN_INSTALLS += $(TOP)/camcom.1
+BIN_INSTALLS += $(TOP)/camcom.help
 
 include $(TOP)/configure/RULES
 include $(TOP)/configure/RULES_TOP

--- a/camcom_support.c
+++ b/camcom_support.c
@@ -353,10 +353,10 @@ void camcom_packet_clean_all()
 	 memset(&packet_bcnt,0,2*NOPS);
          memset(&packet_ctlw,0,4*NOPS);
     }
-  /*
+  /* lorelli: This was commented out in favor of the memset on L359. I'm not sure why, since the revision history here
+   * is rather limited. The memset on L359 unsurprisingly causes a heap buffer overflow. */
   memset(camblk_tok_p,0,camblk_bc);
-  */
-  memset(camblk_tok_p,0,8192);
+  /*memset(camblk_tok_p,0,8192);*/
   memcpy(&camblk_tok_p->control_block.key,"FR",2);
   camblk_tok_p->control_block.nops=NOPS;
   return;

--- a/camcom_support.c
+++ b/camcom_support.c
@@ -726,7 +726,7 @@ void help_type_param(const char* token_p)
          printf("Executing man camcom.1\n");
          execlp("man","man","$EPICS_EXTENSIONS/src/Camcom/camcom.1",0);
 	 */
-         system("man $EPICS_EXTENSIONS/src/Camcom/camcom.1");
+         system("man $EPICS_EXTENSIONS/bin/$EPICS_HOST_ARCH/camcom.1");
        }
      return; 
      }

--- a/camcom_yacc.y
+++ b/camcom_yacc.y
@@ -120,7 +120,7 @@ int main(int argc, char *argv[]) {
     if(strncmp(argv[1],"-h",2)==0)
       {
         printf("Executing vmshelp.py camcom.help");
-        system("vmshelp.py $EPICS_EXTENSIONS/src/Camcom/camcom.help");
+        system("vmshelp.py $EPICS_EXTENSIONS/bin/$EPICS_HOST_ARCH/camcom.help");
         return 0;
       }
 


### PR DESCRIPTION
Unsure as to why the memset was being used with a fixed size of 8192, instead of the seemingly correct commented out one.

This does fix the crash though (confirmed by asan too)